### PR TITLE
Add interactive message flag

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -381,7 +381,6 @@ Sandboxing is enabled by default because YOLO mode is on. You can control it in 
 
 - Using `--sandbox` or `-s` flag.
 - Setting `GEMINI_SANDBOX` environment variable.
-  
 
 By default, it uses a pre-built `gemini-cli-sandbox` Docker image.
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -34,12 +34,13 @@ const logger = {
   error: (...args: any[]) => console.error('[ERROR]', ...args),
 };
 
-interface CliArgs {
+export interface CliArgs {
   model: string | undefined;
   sandbox: boolean | string | undefined;
   'sandbox-image': string | undefined;
   debug: boolean | undefined;
   prompt: string | undefined;
+  message: string | undefined;
   all_files: boolean | undefined;
   show_memory_usage: boolean | undefined;
   yolo: boolean | undefined;
@@ -50,7 +51,7 @@ interface CliArgs {
   telemetryLogPrompts: boolean | undefined;
 }
 
-async function parseArguments(): Promise<CliArgs> {
+export async function parseArguments(): Promise<CliArgs> {
   const argv = await yargs(hideBin(process.argv))
     .option('model', {
       alias: 'm',
@@ -62,6 +63,12 @@ async function parseArguments(): Promise<CliArgs> {
       alias: 'p',
       type: 'string',
       description: 'Prompt. Appended to input on stdin (if any).',
+    })
+    .option('message', {
+      alias: 'i',
+      type: 'string',
+      description:
+        'Send this message automatically in interactive mode (opens UI).',
     })
     .option('sandbox', {
       alias: 's',
@@ -128,6 +135,10 @@ async function parseArguments(): Promise<CliArgs> {
     .help()
     .alias('h', 'help')
     .strict().argv;
+
+  if (!argv.message && Array.isArray(argv._) && argv._.length > 0) {
+    argv.message = argv._.join(' ');
+  }
 
   return argv;
 }

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -40,6 +40,7 @@ vi.mock('./config/config.js', () => ({
     originalModelBeforeSwitch: null,
     finalModel: 'test-model',
   }),
+  parseArguments: vi.fn().mockResolvedValue({ message: undefined }),
 }));
 
 vi.mock('read-package-up', () => ({

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -79,6 +79,7 @@ interface AppProps {
   config: Config;
   settings: LoadedSettings;
   startupWarnings?: string[];
+  initialPrompt?: string;
 }
 
 export const AppWrapper = (props: AppProps) => (
@@ -87,7 +88,12 @@ export const AppWrapper = (props: AppProps) => (
   </SessionStatsProvider>
 );
 
-const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
+const App = ({
+  config,
+  settings,
+  startupWarnings = [],
+  initialPrompt,
+}: AppProps) => {
   useBracketedPaste();
   const [updateMessage, setUpdateMessage] = useState<string | null>(null);
   const { stdout } = useStdout();
@@ -435,6 +441,13 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     },
     [submitQuery],
   );
+
+  useEffect(() => {
+    if (initialPrompt) {
+      handleFinalSubmit(initialPrompt);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const logger = useLogger();
   const [userMessages, setUserMessages] = useState<string[]>([]);


### PR DESCRIPTION
## Summary
- allow CLI to parse leftover args and interactive message via `--message`
- export `parseArguments`
- send initial prompt when launching UI
- update tests

## Testing
- `npm run preflight`

------
https://chatgpt.com/codex/tasks/task_e_686bd3d63d348323a47dbd4a42afbd0b