### PR TITLE
Ensure gemini --message uses cached credentials

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -175,6 +175,18 @@ export async function main() {
 
   // Render UI if in interactive mode with an initial prompt
   if (process.stdin.isTTY && interactivePrompt) {
+    if (settings.merged.selectedAuthType) {
+      try {
+        const err = validateAuthMethod(settings.merged.selectedAuthType);
+        if (err) {
+          throw new Error(err);
+        }
+        await config.refreshAuth(settings.merged.selectedAuthType);
+      } catch (err) {
+        console.error('Error authenticating:', err);
+        process.exit(1);
+      }
+    }
     setWindowTitle(basename(workspaceRoot), settings);
     render(
       <React.StrictMode>


### PR DESCRIPTION
## Summary
- pre-authenticate before launching the UI when `--message` is used so that cached credentials are reused

## Testing
- `npm test` *(fails: Failed to resolve entry for package `@google/gemini-cli-core`)*

------
https://chatgpt.com/codex/tasks/task_e_686bdcc218a08323b27a7ab5a56e76fb