### PR TITLE
Fix mismatched brace in nonInteractiveCli

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -87,7 +87,6 @@ export async function runNonInteractive(
           process.stdout.write(textPart);
           await sendToTelegram(textPart);
         }
-          }
         if (resp.functionCalls) {
           functionCalls.push(...resp.functionCalls);
         }


### PR DESCRIPTION
## Summary
- fix extra closing brace in `nonInteractiveCli.ts`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686beea019fc8323925c392fc4c8a325